### PR TITLE
Fix bug where element that gets cleared is different from element where SVG is drawn

### DIFF
--- a/src/tru_code_renderer.js
+++ b/src/tru_code_renderer.js
@@ -38,6 +38,7 @@ export class TruCodeRenderer {
         }
       }
     }
+    properties.truCodeElementId = properties.truCodeElement.id
 
     this.properties = properties
 
@@ -65,10 +66,11 @@ export class TruCodeRenderer {
     if (this.properties.onPayload) {
       this.properties.onPayload(truCode.payload)
     }
-    this.properties.truCodeElement.innerHTML = ''
+    var element = document.getElementById(this.properties.truCodeElementId)
+    element.innerHTML = ''
     new TruCode(
       SVG(
-        this.properties.truCodeElement.id), truCode.payload,
+        this.properties.truCodeElementId), truCode.payload,
         this.properties.truCodeConfig.qr
     ).draw()
   }


### PR DESCRIPTION
If you have two elements with the same ID, the one you pass in to Trusona.renderTruCode
might not be the same one that gets the SVG, since it is just referenced by ID. This
just does everything by ID, so it should clear the same element that the SVG gets
added to.