### PR TITLE
Fix bug with SVG and clearing using different element

### DIFF
--- a/src/tru_code_renderer.js
+++ b/src/tru_code_renderer.js
@@ -68,7 +68,7 @@ export class TruCodeRenderer {
     this.properties.truCodeElement.innerHTML = ''
     new TruCode(
       SVG(
-        this.properties.truCodeElement.id), truCode.payload,
+        this.properties.truCodeElement), truCode.payload,
         this.properties.truCodeConfig.qr
     ).draw()
   }


### PR DESCRIPTION
If you have two elements with the same ID, getElementById may return a different
element than the one passed in. This change passes the element in to SVG.js,
instead of the ID, so it is guaranteed to render in the same element that was just
cleared.